### PR TITLE
Fix: Correct uniform buffer size for Godot 4.5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Instructions
 
-**For Godot 4.4 users:** I introduced a new Godot 4.4 branch with required fixes. Download from it instead.
-
 1. Take the contents of the "addons" folder and move them to an "addons" folder in your project.
 2. Add an environment node, then add a MotionBlurCompositor (NEW!!) to it.
 3. Add a new PreBlurProcessor effect, which is now required. After it, add a new GuertinMotionBlur, SphynxSimpleJumpFloodMotionBlur, or ExperimentalJumpFloodMotionBlur.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,31 @@
 # Instructions
-1. take the contenst of the "addons" folder and move them to an addons folder in your project. 
-2. add an environment node, add a MotionBlurCompositor(NEW!!) to it
-3. to that, add a new PreBlurProcessor effect, which is now required, and after it add a new GuertinMotionBlur, SphynxSimpleJumpFloodMotionBlur, or ExperimentalJumpFloodMotionBlur
-4. for debugging, add a "C","Z", and "freeze" input events, and then a DebugCompositorEffect to the compositor effects. Then, all you have to do is toggle "Debug" to true on whichever effect you want to show debug for
 
-* GuretinMotionBlur - An all around best blur effect, robust, performant, and now also realistic.
-* SphynxSimpleJumpFloodMotionBlur - An effect driven by a novel dilation method using the jump flood algorithm, used in research of realistic blending schemes and focused on being a retrospective blur approach.
-* ExperimentalJumpFloodMotionBlur - An effect driven by a novel dilation method using the jump flood algorithm, uses an added feature to heuristically fake transparency of leading edge of the blur using the past color output.
+**For Godot 4.4 users:** I introduced a new Godot 4.4 branch with required fixes. Download from it instead.
 
-instructions for radial blur meshes can be seen here:
+1. Take the contents of the "addons" folder and move them to an "addons" folder in your project.
+2. Add an environment node, then add a MotionBlurCompositor (NEW!!) to it.
+3. Add a new PreBlurProcessor effect, which is now required. After it, add a new GuertinMotionBlur, SphynxSimpleJumpFloodMotionBlur, or ExperimentalJumpFloodMotionBlur.
+4. For debugging, add "C", "Z", and "freeze" input events. Then add a DebugCompositorEffect to the compositor effects. Toggle "Debug" to true on whichever effect you want to show debug information for.
+
+* **GuertinMotionBlur** - An all-around best blur effect, robust, performant, and now also realistic.
+* **SphynxSimpleJumpFloodMotionBlur** - An effect driven by a novel dilation method using the jump flood algorithm. It is used in research of realistic blending schemes and focuses on being a retrospective blur approach.
+* **ExperimentalJumpFloodMotionBlur** - An effect driven by a novel dilation method using the jump flood algorithm. It uses an added feature to heuristically fake transparency of the leading edge of the blur using the past color output.
+
+Instructions for radial blur meshes can be seen here:
 https://youtu.be/eslsw9do4Kc
 
-WARNING:
-if you want transparent objects to render on top of the blurred background, you can move the pre-blur-processing and blur post process effects both to callback type of pre-transparent, At which point it would not work if you have MSAA enabled, so make sure to also turn that off.
+**WARNING:**
+If you want transparent objects to render on top of the blurred background, you can move the pre-blur-processing and blur post-process effects both to the callback type of pre-transparent. At this point, it would not work if you have MSAA enabled, so make sure to also turn that off.
 
 # Demo Repo
-you can find a working demo repository here:
+
+You can find a working demo repository here:
 https://github.com/sphynx-owner/JFA_driven_motion_blur_demo
 
 # Sources
-for a better overview of the subject here's a video I made on it:
+
+For a better overview of the subject, here's a video I made on it:
 https://youtu.be/m_KvYlYF3sA
-and heres a paper I wrote on it:
-[Using.the.Jump.Flood.Algorithm.to.Dilate.Velocity.Maps.in.the.application.of.Believable.High.Range.High.Fidelity.Motion.Blur.7_7_24.2.-.Google.Docs.pdf](https://github.com/user-attachments/files/16120346/Using.the.Jump.Flood.Algorithm.to.Dilate.Velocity.Maps.in.the.application.of.Believable.High.Range.High.Fidelity.Motion.Blur.7_7_24.2.-.Google.Docs.pdf)
+
+And here's a paper I wrote on it:
+[Using the Jump Flood Algorithm to Dilate Velocity Maps in the Application of Believable High Range High Fidelity Motion Blur](https://github.com/user-attachments/files/16120346/Using.the.Jump.Flood.Algorithm.to.Dilate.Velocity.Maps.in.the.application.of.Believable.High.Range.High.Fidelity.Motion.Blur.7_7_24.2.-.Google.Docs.pdf)

--- a/addons/SphynxMotionBlurToolkit/BaseClasses/enhanced_compositor_effect.gd
+++ b/addons/SphynxMotionBlurToolkit/BaseClasses/enhanced_compositor_effect.gd
@@ -186,7 +186,7 @@ func ensure_texture(texture_name: StringName, render_scene_buffers: RenderSceneB
 
 	if !render_scene_buffers.has_texture(context, texture_name):
 		var usage_bits: int = RenderingDevice.TEXTURE_USAGE_SAMPLING_BIT | RenderingDevice.TEXTURE_USAGE_STORAGE_BIT
-		render_scene_buffers.create_texture(context, texture_name, texture_format, usage_bits, RenderingDevice.TEXTURE_SAMPLES_1, render_size, 1, 1, true)
+		render_scene_buffers.create_texture(context, texture_name, texture_format, usage_bits, RenderingDevice.TEXTURE_SAMPLES_1, render_size, 1, 1, true, false)
 
 func get_image_uniform(image: RID, binding: int) -> RDUniform:
 	var uniform: RDUniform = RDUniform.new()

--- a/addons/SphynxMotionBlurToolkit/BaseClasses/enhanced_compositor_effect.gd
+++ b/addons/SphynxMotionBlurToolkit/BaseClasses/enhanced_compositor_effect.gd
@@ -4,31 +4,31 @@ var rd: RenderingDevice
 
 var linear_sampler: RID
 
-var nearest_sampler : RID
+var nearest_sampler: RID
 
 var context: StringName = "PostProcess"
 
-var all_shader_stages : Dictionary
+var all_shader_stages: Dictionary
 
-@export var debug : bool = false:
+@export var debug: bool = false:
 	set(value):
-		if(debug == value):
+		if (debug == value):
 			return
 		
 		debug = value
 		free_shaders.call_deferred()
 		generate_shaders.call_deferred()
 
-var debug_1 : String = "debug_1"
-var debug_2 : String = "debug_2"
-var debug_3 : String = "debug_3"
-var debug_4 : String = "debug_4"
-var debug_5 : String = "debug_5"
-var debug_6 : String = "debug_6"
-var debug_7 : String = "debug_7"
-var debug_8 : String = "debug_8"
+var debug_1: String = "debug_1"
+var debug_2: String = "debug_2"
+var debug_3: String = "debug_3"
+var debug_4: String = "debug_4"
+var debug_5: String = "debug_5"
+var debug_6: String = "debug_6"
+var debug_7: String = "debug_7"
+var debug_8: String = "debug_8"
 
-var all_debug_images : Array[RID]
+var all_debug_images: Array[RID]
 
 func _init():
 	RenderingServer.call_on_render_thread(_initialize_compute)
@@ -59,7 +59,7 @@ func generate_shaders():
 		generate_shader_stage(shader_stage)
 
 
-func subscirbe_shader_stage(shader_stage : ShaderStageResource):
+func subscirbe_shader_stage(shader_stage: ShaderStageResource):
 	if all_shader_stages.has(shader_stage):
 		return
 	
@@ -68,7 +68,7 @@ func subscirbe_shader_stage(shader_stage : ShaderStageResource):
 	if rd:
 		generate_shader_stage(shader_stage)
 
-func unsubscribe_shader_stage(shader_stage : ShaderStageResource):
+func unsubscribe_shader_stage(shader_stage: ShaderStageResource):
 	if all_shader_stages.has(shader_stage):
 		all_shader_stages.erase(shader_stage)
 		if !rd:
@@ -104,13 +104,13 @@ func _initialize_compute():
 	generate_shaders()
 
 
-func generate_shader_stage(shader_stage : ShaderStageResource):
-	var shader_spirv : RDShaderSPIRV
+func generate_shader_stage(shader_stage: ShaderStageResource):
+	var shader_spirv: RDShaderSPIRV
 	if debug:
 		var file = FileAccess.open(shader_stage.shader_file.resource_path, FileAccess.READ)
-		var split_shader : PackedStringArray = file.get_as_text().split("#[compute]", true, 1)
-		var content : String = split_shader[min(1, split_shader.size() - 1)]
-		var all_split_parts : PackedStringArray = content.split("#version 450", true, 1)
+		var split_shader: PackedStringArray = file.get_as_text().split("#[compute]", true, 1)
+		var content: String = split_shader[min(1, split_shader.size() - 1)]
+		var all_split_parts: PackedStringArray = content.split("#version 450", true, 1)
 		content = str(all_split_parts[0],
 		"#version 450
 #define DEBUG
@@ -123,7 +123,7 @@ layout(rgba16f, set = 0, binding = 15) uniform image2D debug_6_image;
 layout(rgba16f, set = 0, binding = 16) uniform image2D debug_7_image;
 layout(rgba16f, set = 0, binding = 17) uniform image2D debug_8_image;",
 		all_split_parts[1])
-		var shader_source : RDShaderSource = RDShaderSource.new()
+		var shader_source: RDShaderSource = RDShaderSource.new()
 		shader_source.set_stage_source(RenderingDevice.SHADER_STAGE_COMPUTE, content)
 		shader_spirv = rd.shader_compile_spirv_from_source(shader_source, false)
 		print(content)
@@ -173,11 +173,11 @@ func _render_callback(p_effect_callback_type, p_render_data):
 	
 	all_debug_images.clear()
 
-func _render_callback_2(render_size : Vector2i, render_scene_buffers : RenderSceneBuffersRD, render_scene_data : RenderSceneDataRD):
+func _render_callback_2(render_size: Vector2i, render_scene_buffers: RenderSceneBuffersRD, render_scene_data: RenderSceneDataRD):
 	pass
 
-func ensure_texture(texture_name : StringName, render_scene_buffers : RenderSceneBuffersRD, texture_format : RenderingDevice.DataFormat = RenderingDevice.DATA_FORMAT_R16G16B16A16_SFLOAT, render_size_multiplier : Vector2 = Vector2(1, 1)):
-	var render_size : Vector2i = Vector2(render_scene_buffers.get_internal_size()) * render_size_multiplier
+func ensure_texture(texture_name: StringName, render_scene_buffers: RenderSceneBuffersRD, texture_format: RenderingDevice.DataFormat = RenderingDevice.DATA_FORMAT_R16G16B16A16_SFLOAT, render_size_multiplier: Vector2 = Vector2(1, 1)):
+	var render_size: Vector2i = Vector2(render_scene_buffers.get_internal_size()) * render_size_multiplier
 	
 	if render_scene_buffers.has_texture(context, texture_name):
 		var tf: RDTextureFormat = render_scene_buffers.get_texture_format(context, texture_name)
@@ -195,7 +195,7 @@ func get_image_uniform(image: RID, binding: int) -> RDUniform:
 	uniform.add_id(image)
 	return uniform
 
-func get_sampler_uniform(image: RID, binding: int, linear : bool = true) -> RDUniform:
+func get_sampler_uniform(image: RID, binding: int, linear: bool = true) -> RDUniform:
 	var uniform: RDUniform = RDUniform.new()
 	uniform.uniform_type = RenderingDevice.UNIFORM_TYPE_SAMPLER_WITH_TEXTURE
 	uniform.binding = binding
@@ -203,7 +203,7 @@ func get_sampler_uniform(image: RID, binding: int, linear : bool = true) -> RDUn
 	uniform.add_id(image)
 	return uniform
 
-func dispatch_stage(stage : ShaderStageResource, uniforms : Array[RDUniform], push_constants : PackedByteArray, dispatch_size : Vector3i, label : String = "DefaultLabel", view : int = 0, color : Color = Color(1, 1, 1, 1)):
+func dispatch_stage(stage: ShaderStageResource, uniforms: Array[RDUniform], push_constants: PackedByteArray, dispatch_size: Vector3i, label: String = "DefaultLabel", view: int = 0, color: Color = Color(1, 1, 1, 1)):
 	rd.draw_command_begin_label(label + " " + str(view), color)
 	
 	if debug:

--- a/addons/SphynxMotionBlurToolkit/PreBlurProcessing/Shaders/pre_blur_processor.glsl
+++ b/addons/SphynxMotionBlurToolkit/PreBlurProcessing/Shaders/pre_blur_processor.glsl
@@ -9,63 +9,64 @@ layout(set = 0, binding = 1) uniform sampler2D vector_sampler;
 layout(rgba32f, set = 0, binding = 2) uniform writeonly image2D vector_output;
 
 struct SceneData {
-	highp mat4 projection_matrix;
-	highp mat4 inv_projection_matrix;
-	highp mat4 inv_view_matrix;
-	highp mat4 view_matrix;
+	mat4 projection_matrix;
+	mat4 inv_projection_matrix;
+	mat4 inv_view_matrix;
+	mat4 view_matrix;
 
 	// only used for multiview
-	highp mat4 projection_matrix_view[2];
-	highp mat4 inv_projection_matrix_view[2];
-	highp vec4 eye_offset[2];
+	mat4 projection_matrix_view[MAX_VIEWS];
+	mat4 inv_projection_matrix_view[MAX_VIEWS];
+	vec4 eye_offset[MAX_VIEWS];
 
 	// Used for billboards to cast correct shadows.
-	highp mat4 main_cam_inv_view_matrix;
+	mat4 main_cam_inv_view_matrix;
 
-	highp vec2 viewport_size;
-	highp vec2 screen_pixel_size;
+	vec2 viewport_size;
+	vec2 screen_pixel_size;
 
 	// Use vec4s because std140 doesn't play nice with vec2s, z and w are wasted.
-	highp vec4 directional_penumbra_shadow_kernel[32];
-	highp vec4 directional_soft_shadow_kernel[32];
-	highp vec4 penumbra_shadow_kernel[32];
-	highp vec4 soft_shadow_kernel[32];
+	vec4 directional_penumbra_shadow_kernel[32];
+	vec4 directional_soft_shadow_kernel[32];
+	vec4 penumbra_shadow_kernel[32];
+	vec4 soft_shadow_kernel[32];
 
-	mediump mat3 radiance_inverse_xform;
-
-	mediump vec4 ambient_light_color_energy;
-
-	mediump float ambient_color_sky_mix;
-	bool use_ambient_light;
-	bool use_ambient_cubemap;
-	bool use_reflection_cubemap;
-
-	highp vec2 shadow_atlas_pixel_size;
-	highp vec2 directional_shadow_pixel_size;
+	vec2 shadow_atlas_pixel_size;
+	vec2 directional_shadow_pixel_size;
 
 	uint directional_light_count;
-	mediump float dual_paraboloid_side;
-	highp float z_far;
-	highp float z_near;
+	float dual_paraboloid_side;
+	float z_far;
+	float z_near;
 
-	bool roughness_limiter_enabled;
-	mediump float roughness_limiter_amount;
-	mediump float roughness_limiter_limit;
-	mediump float opaque_prepass_threshold;
+	float roughness_limiter_amount;
+	float roughness_limiter_limit;
+	float opaque_prepass_threshold;
+	uint flags;
 
-	highp float pad;
+	mat3 radiance_inverse_xform;
 
-	mediump float fog_sun_scatter;
-	mediump float fog_aerial_perspective;
-	highp float time;
-	mediump float reflection_multiplier; // one normally, zero when rendering reflections
+	vec4 ambient_light_color_energy;
 
+	float ambient_color_sky_mix;
+	float fog_density;
+	float fog_height;
+	float fog_height_density;
+
+	float fog_depth_curve;
+	float fog_depth_begin;
+	float fog_depth_end;
+	float fog_sun_scatter;
+
+	vec3 fog_light_color;
+	float fog_aerial_perspective;
+
+	float time;
+	float taa_frame_count;
 	vec2 taa_jitter;
-	bool material_uv2_mode;
-	float emissive_exposure_normalization;
 
+	float emissive_exposure_normalization;
 	float IBL_exposure_normalization;
-	bool pancake_shadows;
 	uint camera_visible_layers;
 	float pass_alpha_multiplier;
 };

--- a/addons/SphynxMotionBlurToolkit/PreBlurProcessing/Shaders/pre_blur_processor.glsl
+++ b/addons/SphynxMotionBlurToolkit/PreBlurProcessing/Shaders/pre_blur_processor.glsl
@@ -53,18 +53,7 @@ struct SceneData {
 	mediump float roughness_limiter_limit;
 	mediump float opaque_prepass_threshold;
 
-	bool fog_enabled;
-	uint fog_mode;
-	highp float fog_density;
-	highp float fog_height;
-	highp float fog_height_density;
-
-	highp float fog_depth_curve;
 	highp float pad;
-	highp float fog_depth_begin;
-
-	mediump vec3 fog_light_color;
-	highp float fog_depth_end;
 
 	mediump float fog_sun_scatter;
 	mediump float fog_aerial_perspective;


### PR DESCRIPTION
### Summary

This PR fixes a critical rendering error that occurs when using this addon with Godot 4.5. The engine update appears to have changed the layout for shader uniforms, causing a size mismatch.

### The Problem

When running in Godot 4.5, the following error is thrown, preventing the addon from functioning:

```
Uniform buffer supplied (binding: 5) size (5728) is smaller than size of shader uniform: (5792)
```

This indicates that the data structure being sent to the GPU is 64 bytes smaller than what the shader now expects.

### The Solution

This change updates the relevant struct in the GLSL shader by removing unused variables, allowing the addon to be compatible with Godot 4.5. Tested and confirmed working on `v4.5.dev5`.