### PR TITLE
(Godot 4.5 beta 1) fix generating and adding the motion blur shader to the usable stages

### DIFF
--- a/addons/SphynxMotionBlurToolkit/BaseClasses/enhanced_compositor_effect.gd
+++ b/addons/SphynxMotionBlurToolkit/BaseClasses/enhanced_compositor_effect.gd
@@ -210,6 +210,9 @@ func dispatch_stage(stage: ShaderStageResource, uniforms: Array[RDUniform], push
 		for i in 8:
 			var debug_image_index = i + view * 8;
 			uniforms.append(get_image_uniform(all_debug_images[debug_image_index], 10 + i))
+
+	if (!stage.shader.is_valid()):
+		subscirbe_shader_stage(stage)
 	
 	var tex_uniform_set = UniformSetCacheRD.get_cache(stage.shader, 0, uniforms)
 	


### PR DESCRIPTION
# Fix motion blur shader generation and stage registration for Godot 4.5 beta1 compatibility

## Summary

This PR fixes the generation and adding of the motion blur shader to the usable stages in the enhanced compositor effect. It addresses compatibility issues introduced in Godot 4.5 beta1 where the `@export` setter methods no longer get called at runtime, causing shader stages not to be properly initialized or subscribed.

## Details

The following errors were observed and are fixed by this change:

Root cause:
- `@export` variables no longer call the setter method at runtime.
- The shader stage subscription/unsubscription logic inside the setter never runs.
- This results in shader stages not being properly registered, causing null shader and pipeline errors during rendering.

## Fix

- Introduce explicit initialization code to register the shader stages.

## Additional notes

- This fix is verified against Godot 4.5 beta1.
- The following errors are fixed:

```
enhanced_compositor_effect.gd:214 @ dispatch_stage(): Parameter "shader" is null.
enhanced_compositor_effect.gd:219 @ dispatch_stage(): Condition "rid.is_null()" is true. Returning: rid
enhanced_compositor_effect.gd:222 @ dispatch_stage(): Parameter "pipeline" is null.
enhanced_compositor_effect.gd:223 @ dispatch_stage(): Parameter "uniform_set" is null.
enhanced_compositor_effect.gd:226 @ dispatch_stage(): This compute pipeline requires (0) bytes of push constant data, supplied: (48)
enhanced_compositor_effect.gd:228 @ dispatch_stage(): No compute pipeline was set before attempting to draw.
```
