### PR TITLE
Multiple .tres UID fixes

### DIFF
--- a/addons/SphynxMotionBlurToolkit/Debug/debug_overlay_shader_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/Debug/debug_overlay_shader_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://o2bivm33b0v4"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_rqnmr"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_rqnmr"]
 [ext_resource type="RDShaderFile" uid="uid://dyxn6g5gvoge7" path="res://addons/SphynxMotionBlurToolkit/Debug/ShaderFiles/debug_overlay.glsl" id="2_qgd1y"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/Guertin/guertin_blur_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/Guertin/guertin_blur_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://dre56ajymywpr"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_loemu"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_loemu"]
 [ext_resource type="RDShaderFile" uid="uid://m6rlgfu6i0b3" path="res://addons/SphynxMotionBlurToolkit/Guertin/ShaderFiles/guertin_kino_blur.glsl" id="2_uo41r"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/Guertin/guertin_experimental_blur_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/Guertin/guertin_experimental_blur_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://ca45noqewsyvp"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_kvtxq"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_kvtxq"]
 [ext_resource type="RDShaderFile" uid="uid://br71y0l0rxt8h" path="res://addons/SphynxMotionBlurToolkit/Guertin/ShaderFiles/guertin_experimental_blur.glsl" id="2_ykr12"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/Guertin/guertin_neighbor_max_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/Guertin/guertin_neighbor_max_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://cvb65hfs2lrxo"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_i1bu0"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_i1bu0"]
 [ext_resource type="RDShaderFile" uid="uid://bn88jkvr17x4j" path="res://addons/SphynxMotionBlurToolkit/Guertin/ShaderFiles/guertin_neighbor_max.glsl" id="2_jp4do"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/Guertin/guertin_overlay_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/Guertin/guertin_overlay_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://bidsfymvdyhek"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_2uett"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_2uett"]
 [ext_resource type="RDShaderFile" uid="uid://i6rnwhmss334" path="res://addons/SphynxMotionBlurToolkit/Guertin/ShaderFiles/guertin_overlay.glsl" id="2_evkw4"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/Guertin/guertin_tile_max_x_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/Guertin/guertin_tile_max_x_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://dipvwksvqb3dm"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_bxcqf"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_bxcqf"]
 [ext_resource type="RDShaderFile" uid="uid://d0s5upcgm7r6l" path="res://addons/SphynxMotionBlurToolkit/Guertin/ShaderFiles/guertin_tile_max_x.glsl" id="2_q6kae"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/Guertin/guertin_tile_max_y_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/Guertin/guertin_tile_max_y_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://bxfg45ubc2pv7"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_gy5dj"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_gy5dj"]
 [ext_resource type="RDShaderFile" uid="uid://ceetvitdbio4l" path="res://addons/SphynxMotionBlurToolkit/Guertin/ShaderFiles/guertin_tile_max_y.glsl" id="2_grpec"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/Guertin/guertin_tile_variance_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/Guertin/guertin_tile_variance_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://bqehecsdgt70s"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_kkpwt"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_kkpwt"]
 [ext_resource type="RDShaderFile" uid="uid://by6mslkv0palh" path="res://addons/SphynxMotionBlurToolkit/Guertin/ShaderFiles/guertin_tile_variance.glsl" id="2_r5u5d"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/JumpFlood/experimental_jump_flood_blur_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/JumpFlood/experimental_jump_flood_blur_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://cvavvqqstnm1j"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_3q423"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_3q423"]
 [ext_resource type="RDShaderFile" uid="uid://bud4a7eh5sqr8" path="res://addons/SphynxMotionBlurToolkit/JumpFlood/ShaderFiles/jump_flood_experimental_blur.glsl" id="2_8flx6"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/JumpFlood/jf_simple_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/JumpFlood/jf_simple_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://bj3exhmsfcx4w"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_v4e3u"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_v4e3u"]
 [ext_resource type="RDShaderFile" uid="uid://c4dywnp7k8rph" path="res://addons/SphynxMotionBlurToolkit/JumpFlood/ShaderFiles/jfp_simple.glsl" id="2_msxel"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_blur_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_blur_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://nhb123qs0ja8"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_fyqxe"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_fyqxe"]
 [ext_resource type="RDShaderFile" uid="uid://c57nhlyxb4m1t" path="res://addons/SphynxMotionBlurToolkit/JumpFlood/ShaderFiles/jump_flood_blur.glsl" id="2_c1vs2"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_cache_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_cache_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://bq18dhoelcexm"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_3clo0"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_3clo0"]
 [ext_resource type="RDShaderFile" uid="uid://quuyr2q5w5kx" path="res://addons/SphynxMotionBlurToolkit/JumpFlood/ShaderFiles/jump_flood_cache.glsl" id="2_val47"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_construction_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_construction_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://clwi2fnp1nm3r"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_eeyf1"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_eeyf1"]
 [ext_resource type="RDShaderFile" uid="uid://rkkajixdjosk" path="res://addons/SphynxMotionBlurToolkit/JumpFlood/ShaderFiles/jfp_backtracking_experimental.glsl" id="2_o6bvw"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_neighbor_max_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_neighbor_max_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://co5k7plgmxepi"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_8et3l"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_8et3l"]
 [ext_resource type="RDShaderFile" uid="uid://cfk5chwlcyay4" path="res://addons/SphynxMotionBlurToolkit/JumpFlood/ShaderFiles/jf_neighbor_max.glsl" id="2_fub7x"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_overlay_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_overlay_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://dc5fr84ue3dn5"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_6wgo2"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_6wgo2"]
 [ext_resource type="RDShaderFile" uid="uid://dig08kpnfakuf" path="res://addons/SphynxMotionBlurToolkit/JumpFlood/ShaderFiles/jump_flood_overlay.glsl" id="2_ljukb"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_tile_max_x_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_tile_max_x_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://c10aboaly701b"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_5367c"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_5367c"]
 [ext_resource type="RDShaderFile" uid="uid://djp3da364fk2l" path="res://addons/SphynxMotionBlurToolkit/JumpFlood/ShaderFiles/jf_guertin_tile_max_x.glsl" id="2_1b71e"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_tile_max_y_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/JumpFlood/jump_flood_tile_max_y_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://cymk87e4nyxva"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_5vg08"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_5vg08"]
 [ext_resource type="RDShaderFile" uid="uid://cqlltc8f21wre" path="res://addons/SphynxMotionBlurToolkit/JumpFlood/ShaderFiles/jf_guertin_tile_max_y.glsl" id="2_iusae"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/JumpFlood/realistic_jf_blur_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/JumpFlood/realistic_jf_blur_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://ceav72kvj4qbw"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_qdmen"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_qdmen"]
 [ext_resource type="RDShaderFile" uid="uid://b1fr5qhhrbpst" path="res://addons/SphynxMotionBlurToolkit/JumpFlood/ShaderFiles/jump_flood_realistic_blur.glsl" id="2_bdp68"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/JumpFlood/simple_jf_blur_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/JumpFlood/simple_jf_blur_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://bk5yd5plopwi2"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_ljx3c"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_ljx3c"]
 [ext_resource type="RDShaderFile" uid="uid://c1vndulne5a5r" path="res://addons/SphynxMotionBlurToolkit/JumpFlood/ShaderFiles/jump_flood_simple_new_blur.glsl" id="2_i8sdd"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/LinearBlurToolkit/LinearMotionBlurMesh.tscn
+++ b/addons/SphynxMotionBlurToolkit/LinearBlurToolkit/LinearMotionBlurMesh.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://b8aytbebcsmv8"]
 
-[ext_resource type="Shader" uid="uid://dgf8dfuu6xtxl" path="res://addons/SphynxMotionBlurToolkit/LinearBlurToolkit/LinearMotionBlurMesh.gdshader" id="1_m7mjv"]
-[ext_resource type="Script" uid="uid://bpwvp0aasuaut" path="res://addons/SphynxMotionBlurToolkit/LinearBlurToolkit/linear_motion_blur_mesh.gd" id="2_glqur"]
+[ext_resource type="Shader" uid="uid://b0yo6ig2nsllq" path="res://addons/SphynxMotionBlurToolkit/LinearBlurToolkit/LinearMotionBlurMesh.gdshader" id="1_m7mjv"]
+[ext_resource type="Script" uid="uid://bbm7uwucfi217" path="res://addons/SphynxMotionBlurToolkit/LinearBlurToolkit/linear_motion_blur_mesh.gd" id="2_glqur"]
 
 [sub_resource type="BoxMesh" id="BoxMesh_lylv4"]
 

--- a/addons/SphynxMotionBlurToolkit/McGuire/mcguire_blur_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/McGuire/mcguire_blur_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://cp5pmuoa15e5g"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_16plp"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_16plp"]
 [ext_resource type="RDShaderFile" uid="uid://7fjex8wuiejk" path="res://addons/SphynxMotionBlurToolkit/McGuire/ShaderFiles/mcguire_blur.glsl" id="2_nk2ao"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/McGuire/mcguire_neighbor_max_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/McGuire/mcguire_neighbor_max_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://bk8tn7n5k0b1r"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_6n3p7"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_6n3p7"]
 [ext_resource type="RDShaderFile" uid="uid://byfogr1qtbafi" path="res://addons/SphynxMotionBlurToolkit/McGuire/ShaderFiles/mcguire_neighbor_max.glsl" id="2_ig0yf"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/McGuire/mcguire_overlay_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/McGuire/mcguire_overlay_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://chg1vh0sap86j"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_rpgp3"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_rpgp3"]
 [ext_resource type="RDShaderFile" uid="uid://ylkrbqh7unvl" path="res://addons/SphynxMotionBlurToolkit/McGuire/ShaderFiles/mcguire_overlay.glsl" id="2_sx8p0"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/McGuire/mcguire_tile_max_x_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/McGuire/mcguire_tile_max_x_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://kgrk5sdoor7t"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_50cqr"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_50cqr"]
 [ext_resource type="RDShaderFile" uid="uid://bp5jl5351ph2d" path="res://addons/SphynxMotionBlurToolkit/McGuire/ShaderFiles/mcguire_tile_max_x.glsl" id="2_m4c7y"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/McGuire/mcguire_tile_max_y_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/McGuire/mcguire_tile_max_y_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://d2rdmkpi41wf1"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_4imrj"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_4imrj"]
 [ext_resource type="RDShaderFile" uid="uid://deow8m5u2ji84" path="res://addons/SphynxMotionBlurToolkit/McGuire/ShaderFiles/mcguire_tile_max_y.glsl" id="2_8ewid"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/McGuire/mcguire_tile_variance_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/McGuire/mcguire_tile_variance_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://d1ckx52l74p0"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_bipj1"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_bipj1"]
 [ext_resource type="RDShaderFile" uid="uid://ddo60n85uqwbk" path="res://addons/SphynxMotionBlurToolkit/McGuire/ShaderFiles/mcguire_tile_variance.glsl" id="2_5lusy"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/PreBlurProcessing/default_camera_movement_component.tres
+++ b/addons/SphynxMotionBlurToolkit/PreBlurProcessing/default_camera_movement_component.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="BlurVelocityComponentResource" load_steps=2 format=3 uid="uid://cslvcweyejh3c"]
 
-[ext_resource type="Script" uid="uid://bf0k1mgpkpaph" path="res://addons/SphynxMotionBlurToolkit/PreBlurProcessing/blur_velocity_component_resource.gd" id="1_856ea"]
+[ext_resource type="Script" uid="uid://bb0m2hlp30cxq" path="res://addons/SphynxMotionBlurToolkit/PreBlurProcessing/blur_velocity_component_resource.gd" id="1_856ea"]
 
 [resource]
 script = ExtResource("1_856ea")

--- a/addons/SphynxMotionBlurToolkit/PreBlurProcessing/default_camera_rotation_component.tres
+++ b/addons/SphynxMotionBlurToolkit/PreBlurProcessing/default_camera_rotation_component.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="BlurVelocityComponentResource" load_steps=2 format=3 uid="uid://iru8ynu04i00"]
 
-[ext_resource type="Script" uid="uid://bf0k1mgpkpaph" path="res://addons/SphynxMotionBlurToolkit/PreBlurProcessing/blur_velocity_component_resource.gd" id="1_j2iku"]
+[ext_resource type="Script" uid="uid://bb0m2hlp30cxq" path="res://addons/SphynxMotionBlurToolkit/PreBlurProcessing/blur_velocity_component_resource.gd" id="1_j2iku"]
 
 [resource]
 script = ExtResource("1_j2iku")

--- a/addons/SphynxMotionBlurToolkit/PreBlurProcessing/default_object_movement_component.tres
+++ b/addons/SphynxMotionBlurToolkit/PreBlurProcessing/default_object_movement_component.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="BlurVelocityComponentResource" load_steps=2 format=3 uid="uid://rp3mpjmisoyh"]
 
-[ext_resource type="Script" uid="uid://bf0k1mgpkpaph" path="res://addons/SphynxMotionBlurToolkit/PreBlurProcessing/blur_velocity_component_resource.gd" id="1_ijikr"]
+[ext_resource type="Script" uid="uid://bb0m2hlp30cxq" path="res://addons/SphynxMotionBlurToolkit/PreBlurProcessing/blur_velocity_component_resource.gd" id="1_ijikr"]
 
 [resource]
 script = ExtResource("1_ijikr")

--- a/addons/SphynxMotionBlurToolkit/PreBlurProcessing/pre_blur_processing_stage.tres
+++ b/addons/SphynxMotionBlurToolkit/PreBlurProcessing/pre_blur_processing_stage.tres
@@ -1,6 +1,6 @@
 [gd_resource type="Resource" script_class="ShaderStageResource" load_steps=3 format=3 uid="uid://c8ulad7utgrg7"]
 
-[ext_resource type="Script" uid="uid://bre6lfu0dp38x" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_8hijg"]
+[ext_resource type="Script" uid="uid://g8j232s5j3h6" path="res://addons/SphynxMotionBlurToolkit/BaseClasses/shader_pass_resource.gd" id="1_8hijg"]
 [ext_resource type="RDShaderFile" uid="uid://ojudxyx6f4rx" path="res://addons/SphynxMotionBlurToolkit/PreBlurProcessing/Shaders/pre_blur_processor.glsl" id="2_w54vd"]
 
 [resource]

--- a/addons/SphynxMotionBlurToolkit/RadialBlurToolkit/radial_blur_mesh.tscn
+++ b/addons/SphynxMotionBlurToolkit/RadialBlurToolkit/radial_blur_mesh.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://8p6li7o742g3"]
 
-[ext_resource type="Shader" uid="uid://dolcjg8djw0fj" path="res://addons/SphynxMotionBlurToolkit/RadialBlurToolkit/radial_blur_mesh.gdshader" id="1_36vys"]
-[ext_resource type="Script" uid="uid://duiwswdrbr4q1" path="res://addons/SphynxMotionBlurToolkit/RadialBlurToolkit/radial_blur_mesh.gd" id="2_cfhks"]
+[ext_resource type="Shader" uid="uid://cxg6csyres7j0" path="res://addons/SphynxMotionBlurToolkit/RadialBlurToolkit/radial_blur_mesh.gdshader" id="1_36vys"]
+[ext_resource type="Script" uid="uid://1eg0dywebinh" path="res://addons/SphynxMotionBlurToolkit/RadialBlurToolkit/radial_blur_mesh.gd" id="2_cfhks"]
 
 [sub_resource type="CylinderMesh" id="CylinderMesh_pgvyt"]
 resource_local_to_scene = true


### PR DESCRIPTION
A whole bunch of .tres and .tscn files still had invalid UIDs, probably missed by the Godot upgrade tool. Went in and fixed them all manually.